### PR TITLE
Create audiocontext on first click

### DIFF
--- a/script.js
+++ b/script.js
@@ -157,12 +157,14 @@ window.addEventListener("load", function () {
 
     var instructions = document.createElement("section");
     instructions.className = "instructions";
-    instructions.innerHTML = "<p>Tap the screen with <strong>two fingers to start</strong> playing sound.<br><br>Tap with <strong>three fingers to stop</strong>.</>"
+    instructions.innerHTML = "<p>Click or Touch to Start</p>"
+    if ('ontouchstart' in window) {
+      instructions.innerHTML += '<p class="mobile">Tap the screen with two fingers to start playing sound. Tap with three to stop.</p>'
+    }
 
-    instructions.ontouchstart = function () {
-      playTone("c");
+    instructions.onclick = function () {
+      tones.init();
       document.body.removeChild(instructions);
     }
-    document.body.appendChild(instructions)
-
+    document.body.appendChild(instructions);
 }, false);

--- a/styles.css
+++ b/styles.css
@@ -20,33 +20,29 @@ div:hover, div.auto-playing {
   background-color: white;
 }
 
-/* Instructions for mobile visitors */
 
 .instructions {
+  display: block;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  font-size: 5em;
+  background-color: rgba(255, 255, 255, 0.75);
+  top: 0;
+  border-radius: 10%;
+}
+
+/* Instructions for mobile visitors */
+.instructions .mobile {
   display: none;
 }
 
-@media (max-width: 1000px) {
-  .instructions {
+@media(max-width: 1000px) {
+  .instructions .mobile {
     display: block;
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    font-size: 5em;
-    background-color: rgba(0, 0, 0, 0.25);
-    top: 0;
-    margin: 0;
-  }
-
-  .instructions p {
-    display: block;
-    background-color: white;
-    margin: 1em;
-    margin-top: 3em;
-    padding: 1em;
-    border-radius: 10%;
   }
 }
+
 
 /* Shapes */
 

--- a/tones.js
+++ b/tones.js
@@ -1,13 +1,21 @@
 (function(window) {
     var tones = {
-        context: new (window.AudioContext || window.webkitAudioContext)(),
+        context: null,
         attack: 1,
         release: 100,
         volume: 1,
         type: "sine",
 
+        init: function () {
+            if (!this.context) {
+              this.context = new (window.AudioContext || window.webkitAudioContext)()
+            }
+        },
 
         playFrequency: function(freq) {
+            if (!this.context) {
+              this.context = new (window.AudioContext || window.webkitAudioContext)()
+            }
             this.attack = this.attack || 1;
             this.release = this.release || 1;
             var envelope = this.context.createGain();
@@ -34,8 +42,8 @@
             osc.start();
         },
 
-        /** 
-         * Usage: 
+        /**
+         * Usage:
          * notes.play(440);     // plays 440 hz tone
          * notes.play("c");     // plays note c in default 4th octave
          * notes.play("c#");    // plays note c sharp in default 4th octave
@@ -98,7 +106,7 @@
             "bb": 58.27,
             "b": 61.735
         },
-        {                    
+        {
             // octave 2
             "c": 65.406,
             "c#": 69.296,
@@ -118,7 +126,7 @@
             "bb": 116.541,
             "b": 123.471
         },
-        {                    
+        {
             // octave 3
             "c": 130.813,
             "c#": 138.591,
@@ -138,7 +146,7 @@
             "bb": 233.082,
             "b": 246.942
         },
-        {                    
+        {
             // octave 4
             "c": 261.626,
             "c#": 277.183,
@@ -158,7 +166,7 @@
             "bb": 466.164,
             "b": 493.883
         },
-        {                    
+        {
             // octave 5
             "c": 523.251,
             "c#": 554.365,
@@ -178,7 +186,7 @@
             "bb": 932.328,
             "b": 987.767
         },
-        {                    
+        {
             // octave 6
             "c": 1046.502,
             "c#": 1108.731,
@@ -198,7 +206,7 @@
             "bb": 1864.655,
             "b": 1975.533
         },
-        {                    
+        {
             // octave 7
             "c": 2093.005,
             "c#": 2217.461,
@@ -218,7 +226,7 @@
             "bb": 3729.31,
             "b": 3951.066
         },
-        {                    
+        {
             // octave 8
             "c": 4186.009,
             "c#": 4434.922,
@@ -238,7 +246,7 @@
             "bb": 7458.62,
             "b": 7902.132
         },
-        {                    
+        {
             // octave 9
             "c": 8372.018,
             "c#": 8869.844,
@@ -261,7 +269,7 @@
     };
 
     // need to create a node in order to kick off the timer in Chrome.
-    tones.context.createGain();
+    //tones.context.createGain();
 
     if (typeof define === "function" && define.amd) {
         define(tones);


### PR DESCRIPTION
We need the audiocontext to be created from a user input. This does it
for web and mobile (using `onclick`, which works as touch on mobile)
and leaves the existing two-touch to start, three-touch to stop
for mobile.